### PR TITLE
fix: revert back to docker/metadata-action v5.5.1

### DIFF
--- a/.github/workflows/reusable-docker-build-push.yaml
+++ b/.github/workflows/reusable-docker-build-push.yaml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Docker metadata
         id: metadata
-        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
         with:
           tags: |
             type=raw,value=${{ inputs.image-tag }}


### PR DESCRIPTION
# Description

revert to v5.5.1 for docker/metadata-action

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
