### PR TITLE
fix: adding default values to MetricResult attributes.

### DIFF
--- a/metrics_computation_engine/src/metrics_computation_engine/models/eval.py
+++ b/metrics_computation_engine/src/metrics_computation_engine/models/eval.py
@@ -1,7 +1,7 @@
 # Copyright AGNTCY Contributors (https://github.com/agntcy)
 # SPDX-License-Identifier: Apache-2.0
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel, Field
@@ -12,18 +12,18 @@ class MetricResult:
     """Result of a metric computation"""
 
     metric_name: str
-    description: str
     value: Union[float, int, str, Dict[str, Any]]
-    reasoning: str
-    unit: str
     aggregation_level: str
-    span_id: List[str]
-    session_id: List[str]
-    source: str
-    entities_involved: List[str]
-    edges_involved: List[str]
-    success: bool
-    metadata: Dict[str, Any]
+    description: str = ""
+    reasoning: str = ""
+    unit: str = ""
+    span_id: List[str] = field(default_factory=list)
+    session_id: List[str] = field(default_factory=list)
+    source: str = ""
+    entities_involved: List[str] = field(default_factory=list)
+    edges_involved: List[str] = field(default_factory=list)
+    success: bool = False
+    metadata: Dict[str, Any] = field(default_factory=dict)
     # timestamp: datetime
     error_message: Optional[str] = None
 

--- a/metrics_computation_engine/src/metrics_computation_engine/processor.py
+++ b/metrics_computation_engine/src/metrics_computation_engine/processor.py
@@ -39,7 +39,7 @@ class MetricsProcessor:
         except Exception as e:
             # Return error result instead of crashing
             return MetricResult(
-                name=metric.name,
+                metric_name=metric.name,
                 value=-1,
                 error_message=str(e),
                 aggregation_level=metric.aggregation_level,


### PR DESCRIPTION
# Description

This PR adds default values for attributes of the MetricResult class.
It also fixes an attribute name mismatch when calling the MetricResult constructor upon metric computation exception in the processor.

## Type of Change

- [X] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [X] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [X] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
