### PR TITLE
fix: Graph determinism score update

### DIFF
--- a/metrics_computation_engine/src/metrics_computation_engine/metrics/population/graph_determinism_score.py
+++ b/metrics_computation_engine/src/metrics_computation_engine/metrics/population/graph_determinism_score.py
@@ -46,11 +46,11 @@ class GraphDeterminismScore(BaseMetric):
                 for span in session_entity.spans:
                     if span.entity_type in ["agent", "tool"]:
                         filtered_events.append(span.entity_name)
-                
+
                 edges = []
                 for i in range(len(filtered_events) - 1):
                     edges.append((filtered_events[i], filtered_events[i + 1]))
-                
+
                 graphs.append(edges)
 
             # Create NetworkX graphs
@@ -71,7 +71,7 @@ class GraphDeterminismScore(BaseMetric):
 
             variance = -1
             error_message = None
-            
+
             if edit_distances:
                 variance = sum(edit_distances) / len(edit_distances)
             elif len(nx_graphs) < 2:
@@ -95,7 +95,7 @@ class GraphDeterminismScore(BaseMetric):
                 metadata={
                     "total_graphs": len(nx_graphs),
                     "pairwise_comparisons": len(edit_distances),
-                    "edit_distances": edit_distances if edit_distances else []
+                    "edit_distances": edit_distances if edit_distances else [],
                 },
                 error_message=error_message,
             )


### PR DESCRIPTION
# Description

A fix to have our Graph Determinism Score which is a population level metric, to operate on the Session Entities. Currently they are operating on an older data schema.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
