### PR TITLE
fix: gorm import no longer needed here

### DIFF
--- a/api-layer/pkg/services/clickhouse/handlers/session_handler.go
+++ b/api-layer/pkg/services/clickhouse/handlers/session_handler.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/agntcy/telemetry-hub/api-layer/pkg/services/clickhouse/models"
-	"gorm.io/gorm"
 )
 
 func (h Handler) GetSessionIDS(startTime, endTime time.Time) ([]models.SessionID, error) {


### PR DESCRIPTION
# Description

Gorm is already defined in handler.go and not needed to explicitly import in these functions

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
