### PR TITLE
docs: Licensing update

### DIFF
--- a/metrics_computation_engine/plugins/adapters/opik_adapter/src/mce_opik_adapter/__init__.py
+++ b/metrics_computation_engine/plugins/adapters/opik_adapter/src/mce_opik_adapter/__init__.py
@@ -1,3 +1,6 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
 from .model_loader import load_model
 
 __all__ = ["load_model"]

--- a/metrics_computation_engine/plugins/adapters/opik_adapter/src/mce_opik_adapter/adapter.py
+++ b/metrics_computation_engine/plugins/adapters/opik_adapter/src/mce_opik_adapter/adapter.py
@@ -1,3 +1,6 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
 from typing import Tuple, Any, Dict, List
 import importlib
 

--- a/metrics_computation_engine/plugins/adapters/opik_adapter/src/mce_opik_adapter/metric_configuration.py
+++ b/metrics_computation_engine/plugins/adapters/opik_adapter/src/mce_opik_adapter/metric_configuration.py
@@ -1,3 +1,6 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
 from typing import Any, Dict, List, Optional
 
 from mce_opik_adapter.metric_test_case_creation import (

--- a/metrics_computation_engine/plugins/adapters/opik_adapter/src/mce_opik_adapter/metric_test_case_creation.py
+++ b/metrics_computation_engine/plugins/adapters/opik_adapter/src/mce_opik_adapter/metric_test_case_creation.py
@@ -1,3 +1,6 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
 from abc import ABCMeta, abstractmethod
 from typing import Union, Dict, Any
 

--- a/metrics_computation_engine/plugins/adapters/opik_adapter/src/mce_opik_adapter/model_loader.py
+++ b/metrics_computation_engine/plugins/adapters/opik_adapter/src/mce_opik_adapter/model_loader.py
@@ -1,3 +1,6 @@
+# Copyright AGNTCY Contributors (https://github.com/agntcy)
+# SPDX-License-Identifier: Apache-2.0
+
 from typing import Any
 from opik.evaluation import models
 from metrics_computation_engine.models.requests import LLMJudgeConfig


### PR DESCRIPTION
# Description

Fixing the licensing of the opik adapter as it can trigger security warnings, despite the intended Apache 2.0 license.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
