### PR TITLE
feat: enabling sentiment metric

### DIFF
--- a/metrics_computation_engine/plugins/adapters/opik_adapter/src/mce_opik_adapter/metric_configuration.py
+++ b/metrics_computation_engine/plugins/adapters/opik_adapter/src/mce_opik_adapter/metric_configuration.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional
 from mce_opik_adapter.metric_test_case_creation import (
     AbstractTestCaseCalculator,
     OpikHallucinationTestCase,
+    OpikSpanTestCase,
 )
 from pydantic import BaseModel, Field
 
@@ -41,5 +42,14 @@ def build_metric_configurations() -> List[MetricConfiguration]:
                 aggregation_level="span",
                 required_input_parameters=["input_payload", "output_payload"],
             ),
-        )
+        ),
+        MetricConfiguration(
+            metric_name="Sentiment",
+            test_case_calculator=OpikSpanTestCase(),
+            requirements=MetricRequirements(
+                entity_type=["llm"],
+                aggregation_level="span",
+                required_input_parameters=["input_payload", "output_payload"],
+            ),
+        ),
     ]


### PR DESCRIPTION
# Description

The new refactor for adapter metrics puts hard constraints on the metrics you can use from them. Added this block to enable the sentiment metric. 

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
