### PR TITLE
feat: adding prompt to the api-layer session summary

### DIFF
--- a/api-layer/pkg/services/clickhouse/models/otel_insights.go
+++ b/api-layer/pkg/services/clickhouse/models/otel_insights.go
@@ -40,6 +40,7 @@ type SessionID struct {
 type SessionUniqueID struct {
 	ID             string `json:"id"`
 	StartTimestamp string `json:"start_timestamp"`
+    Prompt         string `json:"prompt"`
 }
 
 type TraceId struct {


### PR DESCRIPTION
# Description
These changes allow the api-layer http://<>/traces/sessions to show the prompt that triggered the session. For example:

{
  "data": [
    {
      "id": "corto.exchange_f078d18a-c4ed-4177-b13b-b8358ad0f1f7",
      "start_timestamp": "2025-10-02T13:46:52.648685Z",
      "prompt": "What is the taste of Robusta coffee?"
    },
    {
      "id": "corto.exchange_7df41032-23b0-4081-9c9d-3f775bba8054",
      "start_timestamp": "2025-10-02T13:46:48.35102Z",
      "prompt": "What is the taste of Arabica coffee?"
    },
    {
      "id": "corto.exchange_cf4e40da-c25f-49d4-a2fc-332924b7e718",
      "start_timestamp": "2025-10-02T13:46:41.663386Z",
      "prompt": "What are the different flavors of coffee?"
    }
  ],
  "total": 3
}


## Type of Change

- [] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
