### PR TITLE
chore: bump adapter versions to 0.1.1

### DIFF
--- a/metrics_computation_engine/plugins/adapters/deepeval_adapter/pyproject.toml
+++ b/metrics_computation_engine/plugins/adapters/deepeval_adapter/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mce-deepeval-adapter"
-version = "0.1.0"
+version = "0.1.1"
 license = "Apache-2.0"
 description = "DeepEval integration adapter for Metrics Computation Engine"
 authors = [

--- a/metrics_computation_engine/plugins/adapters/opik_adapter/pyproject.toml
+++ b/metrics_computation_engine/plugins/adapters/opik_adapter/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mce-opik-adapter"
-version = "0.1.0"
+version = "0.1.1"
 license = "Apache-2.0"
 description = "Opik integration adapter for Metrics Computation Engine"
 authors = [

--- a/metrics_computation_engine/plugins/adapters/ragas_adapter/pyproject.toml
+++ b/metrics_computation_engine/plugins/adapters/ragas_adapter/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mce-ragas-adapter"
-version = "0.1.0"
+version = "0.1.1"
 license = "Apache-2.0"
 description = "RAGAS integration adapter for Metrics Computation Engine"
 authors = [


### PR DESCRIPTION
# Description

- mce-opik-adapter: 0.1.0 -> 0.1.1
- mce-ragas-adapter: 0.1.0 -> 0.1.1
- mce-deepeval-adapter: 0.1.0 -> 0.1.1

This aligns the pyproject.toml versions with the git tags that were already pushed (mce-opik-adapter-v0.1.1, mce-ragas-adapter-v0.1.1, mce-deepeval-adapter-v0.1.1).

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
