### PR TITLE
chore: bump mce plugin versions to 0.1.2

### DIFF
--- a/metrics_computation_engine/plugins/mce_metrics_plugin/pyproject.toml
+++ b/metrics_computation_engine/plugins/mce_metrics_plugin/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mce_metrics_plugin"
-version = "0.1.1"
+version = "0.1.2"
 license = "Apache-2.0"
 description = "Metrics plugin"
 authors = [


### PR DESCRIPTION
# Description

mce-metrics-plugin-v0.1.1 -> mce-metrics-plugin-v0.1.2
Updates release to use the new MCE setup

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [contributing guidelines](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
