### PR TITLE
fix: closing outbound unwanted outbound telemetry

### DIFF
--- a/metrics_computation_engine/plugins/adapters/deepeval_adapter/src/mce_deepeval_adapter/adapter.py
+++ b/metrics_computation_engine/plugins/adapters/deepeval_adapter/src/mce_deepeval_adapter/adapter.py
@@ -15,7 +15,8 @@ from .metric_configuration import MetricConfiguration, build_metric_configuratio
 from .model_loader import MODEL_PROVIDER_NAME, load_model
 
 import os
-os.environ["DEEPEVAL_TELEMETRY_OPT_OUT"]="1"
+
+os.environ["DEEPEVAL_TELEMETRY_OPT_OUT"] = "1"
 
 logger = setup_logger(__name__)
 

--- a/metrics_computation_engine/plugins/adapters/opik_adapter/src/mce_opik_adapter/adapter.py
+++ b/metrics_computation_engine/plugins/adapters/opik_adapter/src/mce_opik_adapter/adapter.py
@@ -59,9 +59,11 @@ class OpikMetricAdapter(BaseMetric):
         self.required = {
             "entity_type": self.metric_configuration.requirements.entity_type
         }
-        
+
         # Should be false
-        logger.info(f"OPIK TRACING: opik.is_tracing_active(): {opik.is_tracing_active()}")
+        logger.info(
+            f"OPIK TRACING: opik.is_tracing_active(): {opik.is_tracing_active()}"
+        )
 
     def get_model_provider(self):
         return MODEL_PROVIDER_NAME


### PR DESCRIPTION
# Description

Several environmental variables need to be adjusted to prevent 3rd party adapters from collecting usage metrics or attempting to send data to their platform.

A test confirming that unwanted outbound requests are no longer sent was done using mitmproxy

## DeepEval

To opt out of telemetry globally, set the following environment variable:

```bash
DEEPEVAL_TELEMETRY_OPT_OUT=1
```

**Reference:** [[DeepEval .env.example](https://github.com/confident-ai/deepeval/blob/ea1e8ede16dfe412393406321228228be8b5d331/.env.example#L83)](https://github.com/confident-ai/deepeval/blob/ea1e8ede16dfe412393406321228228be8b5d331/.env.example#L83)

## Opik

To control tracing in Opik, use the following methods:

```python
import opik

# Check the current state of the tracing flag
print(opik.is_tracing_active())

# Disable the logging process
opik.set_tracing_active(False)

# Re-enable the logging process
opik.set_tracing_active(True)
```

**Reference:** [[Opik Tracing Documentation](https://www.comet.com/docs/opik/tracing/log_traces)](https://www.comet.com/docs/opik/tracing/log_traces)

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the [[contributing guidelines](https://claude.ai/agntcy/repo-template/blob/main/CONTRIBUTING.md)](/agntcy/repo-template/blob/main/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
